### PR TITLE
Generate blocks with the correct minimum times

### DIFF
--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -2217,7 +2217,8 @@ Value getblocktemplate(const Array& params, bool fHelp)
         result.push_back(Pair("coinbaseaux", aux));
         result.push_back(Pair("coinbasevalue", (int64_t)pblock->vtx[0].vout[0].nValue));
         result.push_back(Pair("target", hashTarget.GetHex()));
-        result.push_back(Pair("mintime", (int64_t)pindexPrev->GetMedianTimePast()+1));
+        result.push_back(Pair("mintime", (int64_t)(pindexPrev->GetBlockTime()+60+1)));
+
         result.push_back(Pair("mutable", aMutable));
         result.push_back(Pair("noncerange", "00000000ffffffff"));
         result.push_back(Pair("sigoplimit", (int64_t)MAX_BLOCK_SIGOPS));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1009,6 +1009,8 @@ void static InvalidChainFound(CBlockIndex* pindexNew)
 
 void CBlock::UpdateTime(const CBlockIndex* pindexPrev)
 {
+    nTime = max(pindexPrev->GetBlockTime()+60+1, GetBlockTime());
+    nTime = max(GetAdjustedTime(), GetBlockTime());
     nTime = max(GetBlockTime(), GetAdjustedTime());
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1969,9 +1969,15 @@ bool CBlock::AcceptBlock()
     if (nBits != GetNextTargetRequired(pindexPrev, IsProofOfStake()))
         return DoS(100, error("AcceptBlock() : incorrect proof-of-work/proof-of-stake"));
 
+
+    if (nHeight > 250000){
+        if (GetBlockTime() <= (pindexPrev->GetBlockTime() + 60))
+            return error("AcceptBlock(height=%d) : block's timestamp (%"PRI64d") is too soon after prev(%"PRI64d")", nHeight, GetBlockTime(), pindexPrev->GetBlockTime());
+    } else {
     // Check timestamp against prev
     if (GetBlockTime() <= pindexPrev->GetMedianTimePast() || GetBlockTime() + nMaxClockDrift < pindexPrev->GetBlockTime())
         return error("AcceptBlock() : block's timestamp is too early");
+    }
 
     // Check that all transactions are finalized
     BOOST_FOREACH(const CTransaction& tx, vtx)


### PR DESCRIPTION
Fix to create blocks with block times acceptable to the new release.

This version does NOT enforce the new minimum requirements with the legacy code, another patch will be needed for that.
